### PR TITLE
Add return type

### DIFF
--- a/Extension/PagerfantaExtension.php
+++ b/Extension/PagerfantaExtension.php
@@ -7,7 +7,7 @@ use Twig\TwigFunction;
 
 final class PagerfantaExtension extends AbstractExtension
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('pagerfanta', [PagerfantaRuntime::class, 'renderPagerfanta'], ['is_safe' => ['html']]),


### PR DESCRIPTION
```
Method "Twig\Extension\ExtensionInterface::getFunctions()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pagerfanta\Twig\Extension\PagerfantaExtension" now to avoid errors or add an explicit @return annotation to suppress this message.
```